### PR TITLE
transport: support generic types

### DIFF
--- a/src/main/java/com/clouway/chita/HttpRequest.java
+++ b/src/main/java/com/clouway/chita/HttpRequest.java
@@ -41,8 +41,8 @@ public class HttpRequest<T>{
   private static final Logger log = Logger.getLogger(HttpRequest.class.getName());
 
 
-  public static Builder httpRequest(TargetUrl url) {
-    return new Builder(url);
+  public static <T> Builder<T> httpRequest(TargetUrl url) {
+    return new Builder<T>(url);
   }
 
   public static class Builder<T> {

--- a/src/main/java/com/clouway/chita/HttpResponse.java
+++ b/src/main/java/com/clouway/chita/HttpResponse.java
@@ -1,5 +1,6 @@
 package com.clouway.chita;
 
+import com.google.inject.TypeLiteral;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -94,6 +95,28 @@ public class HttpResponse {
       }
     };
   }
+
+
+  public <E> ResponseRead<E> read(final TypeLiteral<E> entityClazz) {
+    return new ResponseRead<E>() {
+      @Override
+      public E as(Class<? extends Transport> clazz) {
+        E result = null;
+        try {
+          Transport transport = clazz.newInstance();
+          result = transport.in(inputStream, entityClazz);
+        } catch (InstantiationException e) {
+          e.printStackTrace();
+        } catch (IllegalAccessException e) {
+          e.printStackTrace();
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+        return result;
+      }
+    };
+  }
+
 
   /**
    * Returns the response as byte array

--- a/src/main/java/com/clouway/chita/TextTransport.java
+++ b/src/main/java/com/clouway/chita/TextTransport.java
@@ -1,5 +1,6 @@
 package com.clouway.chita;
 
+import com.google.inject.TypeLiteral;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -15,6 +16,11 @@ public class TextTransport implements Transport {
   @Override
   public <T> T in(InputStream in, Class<T> type) throws IOException {
     return type.cast(IOUtils.toString(in));
+  }
+
+  @Override
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    return (T)IOUtils.toString(in);
   }
 
   @Override

--- a/src/main/java/com/clouway/chita/Transport.java
+++ b/src/main/java/com/clouway/chita/Transport.java
@@ -1,5 +1,7 @@
 package com.clouway.chita;
 
+import com.google.inject.TypeLiteral;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -9,6 +11,8 @@ import java.io.OutputStream;
  */
 public interface Transport {
   <T> T in(InputStream in, Class<T> type) throws IOException;
+
+  <T> T in(InputStream in, TypeLiteral<T> type) throws IOException;
 
   <T> void out(OutputStream out, Class<T> type, T data) throws IOException;
 

--- a/src/test/java/com/clouway/chita/CustomTransport.java
+++ b/src/test/java/com/clouway/chita/CustomTransport.java
@@ -2,6 +2,7 @@ package com.clouway.chita;
 
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
+import com.google.inject.TypeLiteral;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -14,9 +15,15 @@ import java.io.UnsupportedEncodingException;
  * @author Tsony Tsonev (tsony.tsonev@clouway.com)
  */
 public class CustomTransport implements Transport {
+
   @Override
   public <T> T in(InputStream in, Class<T> type) throws IOException {
     return new Gson().fromJson(new InputStreamReader(in), type);
+  }
+
+  @Override
+  public <T> T in(InputStream in, TypeLiteral<T> type) throws IOException {
+    return new Gson().fromJson(new InputStreamReader(in), type.getType());
   }
 
   @Override


### PR DESCRIPTION
added support for generic types that uses com.google.inject cause it's added as dependency to the library and is required.

Fixes issue #17 