### PR TITLE
http: preserve header ordering

### DIFF
--- a/src/main/java/com/clouway/chita/HttpRequest.java
+++ b/src/main/java/com/clouway/chita/HttpRequest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.codec.binary.Base64;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -34,12 +35,13 @@ import java.util.logging.Logger;
  *   HttpRequest request = httpRequest(targetUrl).put(address).as(GsonTransport.class).build();
  * </pre>
  *
+ * <p/>
+ * This class maintains the order of the header fields within the HTTP message, so the developers are able
+ * to specify correct header order depending of the situation.
+ *
  * @author Mihail Lesikov (mlesikov@gmail.com)
  */
 public class HttpRequest<T>{
-
-  private static final Logger log = Logger.getLogger(HttpRequest.class.getName());
-
 
   public static <T> Builder<T> httpRequest(TargetUrl url) {
     return new Builder<T>(url);
@@ -55,7 +57,7 @@ public class HttpRequest<T>{
 
     private String contentType;
 
-    private Map<String, String> properties = new HashMap<String, String>();
+    private Map<String, String> properties = new LinkedHashMap<String, String>();
 
     private int connectTimeout = 10000;
 

--- a/src/test/java/com/clouway/chita/PreserveHeaderOrderTest.java
+++ b/src/test/java/com/clouway/chita/PreserveHeaderOrderTest.java
@@ -1,0 +1,41 @@
+package com.clouway.chita;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.clouway.chita.HttpRequest.httpRequest;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.*;
+
+
+/**
+ * @author Miroslav Genov (miroslav.genov@clouway.com)
+ */
+public class PreserveHeaderOrderTest {
+
+  @Test
+  public void happyPath() {
+    HttpRequest<?> request = httpRequest(new TargetUrl("http://hostofapp.com"))
+            .addProperty("1", "1")
+            .addProperty("3", "3")
+            .addProperty("2", "2").build();
+
+    Map<String, String> properties = request.getProperties();
+    assertThat(properties.keySet(), contains("1", "3", "2"));
+  }
+
+  @Test
+  public void anotherOrdering() {
+    HttpRequest<?> request = httpRequest(new TargetUrl("http://hostofapp.com"))
+            .addProperty("1", "1")
+            .addProperty("2", "2")
+            .addProperty("3", "3").build();
+
+    Map<String, String> properties = request.getProperties();
+    assertThat(properties.keySet(), contains("1", "2", "3"));
+  }
+
+}


### PR DESCRIPTION
Header order is now preserved on building of the request. Builder now
uses LinkedHashMap instead of Map for holding of headers before they are
send through the network to the server.

Fixes #35