### PR TITLE
http: allow simple string calls

### DIFF
--- a/src/main/java/com/clouway/chita/HttpClient.java
+++ b/src/main/java/com/clouway/chita/HttpClient.java
@@ -1,5 +1,6 @@
 package com.clouway.chita;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
 import java.io.IOException;
@@ -105,6 +106,12 @@ public class HttpClient {
 
           conn.setRequestProperty("Content-Type", request.getContentType());
 
+        } else if (body instanceof String) {
+          out = conn.getOutputStream();
+
+          String stringBody = (String) body;
+          out.write(stringBody.getBytes(Charsets.UTF_8));
+          out.flush();
         }
 
         if (conn.getErrorStream() != null || conn.getResponseCode() >= 400) {


### PR DESCRIPTION
When String content is provided for post or put it is send through the
output stream to the target server, which prevents missing of content
when transport is not specified.

Example:

``` java
String content = "body message";
HttpResponse response = client.execute(httpRequest(new TargetUrl(endpoint))
              .post(content)
              .addProperty("Content-Type", "text/xml; charset=utf-8")
              .build());
```

Fixes #39
